### PR TITLE
Update composer.json with braintree 3.6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.0",
         "illuminate/support": "5.x",
         "laravel/framework": "5.x",
-        "braintree/braintree_php": "3.5.x"
+        "braintree/braintree_php": "3.6.x"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Unable to perform composer install if braintree is 3.5.x
